### PR TITLE
Korrektur der Platzhalterbilder

### DIFF
--- a/templates/list_router.php
+++ b/templates/list_router.php
@@ -175,7 +175,7 @@ if($input->urlSegment1 == "json"){
 
   foreach($routers as $router){
     $title = $router->title;
-    $image = (count($router->image) ? $router->image->first()->size(300,300)->url : 'https://placehold.it/300x300');
+    $image = (count($router->image) ? $router->image->first()->size(300,300)->url : 'https://place-hold.it/300x300');
     $features = getTag($router->features, 2);
 
     $output .= "<a href='{$router->httpUrl}'>

--- a/templates/markup/home.inc
+++ b/templates/markup/home.inc
@@ -62,7 +62,7 @@
       </p>
       <div class='row info-box'>
         <div class='columns large-4'>
-          <img class='responsive' src='https://placehold.it/350x200'></img>
+          <img class='responsive' src='https://place-hold.it/350x200'></img>
         </div>
         <div class='columns large-8 text-justify'>
           <h4>Freifunk-Router</h4>
@@ -78,13 +78,13 @@
             <br/>Der Austrittsort befindet sich im EU-Ausland oder bei einem Internetprovider, sodass die sonst übliche Störerhaftung nicht zutrifft. Da eine Webseite nur den Austrittsort sieht kann es vorkommen das Google auf Schwedisch oder Holländisch ist da es denkt das man sich dort befindet.</p>
         </div>
         <div class='columns large-4'>
-          <img class='responsive' src='https://placehold.it/350x200'></img>
+          <img class='responsive' src='https://place-hold.it/350x200'></img>
         </div>
       </div>
 
       <div class='row info-box'>
         <div class='columns large-4 '>
-          <img class='responsive' src='https://placehold.it/350x200'></img>
+          <img class='responsive' src='https://place-hold.it/350x200'></img>
         </div>
         <div class='columns large-8 text-justify'>
           <h4>Für wen ist Freifunk?</h4>


### PR DESCRIPTION
Moin,

Ich hoffe einfach mal, dass Deutsch in diesem Fall ok ist. 😃 
Ich hab mal schnell die Platzhalter auf der Startseite und für die Router korrigiert.

Das ist zwar immer noch nicht optimal, macht aber so sicherlich schon mal einen freundlicheren Eindruck
als broken image Darstellungen.
Außerdem ist die Routerliste mit den fehlenden Bildern total unförmig.

Allgemein:
Gibt's ne To-Do Liste für die Homepage bzw. wäre so etwas eher ein Gesprächsthema für das nächste Treffen im März?

Edit:
Man kann aus den Issues ja schon das ein oder andere rauslesen an To-Do's

Viele Grüße
Jerome