### PR TITLE
Update _main.inc

### DIFF
--- a/templates/_main.inc
+++ b/templates/_main.inc
@@ -124,6 +124,7 @@ if(!wire('user')->isLoggedin()){
           <li><a href="<?=$pages->get("/about/")->url?>">About</a></li>
           <li><a href="https://wiki.freifunk-myk.de/wiki/faq">Faq</a></li>
           <li><a href="<?=$pages->get("/kontakt/")->url?>">Kontakt</a></li>
+	  <li><a href="<?=$pages->get("/impressum/")->url?>">Impressum</a></li>
         </ul>
         <p class="copywrite">Erstellt mit <a href="http://de.processwire.com/">ProcessWire</a> und <a href="http://foundation.zurb.com/">Foundation Zurb</a>. Zu finden auf <a href="https://github.com/FreifunkMYK/PW-Freifunk-Starter">GitHub</a>.
       </div>


### PR DESCRIPTION
Quick Fix für #83 

Ich hab das einfach mal per Copy/Paste in den Footer gepackt.

Sieht nur auf einem Hochkant Smartphone vielleicht etwas gepresst aus so.
Aber für die gesetzlichen Anforderungen sollte es damit schon mal reichen.

(Screenshots aus den Dev Tools, wo ich es einfach mal in html testweise reingesetzt hatte.
![www freifunk-myk de_impressum_ galaxy s5](https://user-images.githubusercontent.com/7161177/36751661-10ecf524-1c01-11e8-975a-fe1c9a1e3b59.png)

![www freifunk-myk de_impressum_ galaxy s5 1](https://user-images.githubusercontent.com/7161177/36751667-1359fc76-1c01-11e8-80fd-e140194628e7.png)
